### PR TITLE
Apply shield to metagraph

### DIFF
--- a/bt_ddos_shield/blockchain_manager.py
+++ b/bt_ddos_shield/blockchain_manager.py
@@ -97,9 +97,7 @@ class BittensorBlockchainManager(AbstractBlockchainManager):
     async def get_metadata(self, hotkeys: Iterable[Hotkey]) -> Dict[Hotkey, Optional[bytes]]:
         try:
             async with bittensor.AsyncSubtensor(self.subtensor.chain_endpoint) as async_subtensor:
-                tasks = [
-                    self.get_single_metadata(async_subtensor, hotkey) for hotkey in hotkeys
-                ]
+                tasks = [self.get_single_metadata(async_subtensor, hotkey) for hotkey in hotkeys]
                 results = await asyncio.gather(*tasks)
             return dict(zip(hotkeys, results))
         except Exception as e:

--- a/bt_ddos_shield/blockchain_manager.py
+++ b/bt_ddos_shield/blockchain_manager.py
@@ -4,7 +4,6 @@ from typing import Optional
 import bittensor
 import bittensor_wallet
 from bittensor.core.extrinsics.serving import (
-    get_metadata,
     publish_metadata,
 )
 from bt_ddos_shield.event_processor import AbstractMinerShieldEventProcessor
@@ -26,11 +25,11 @@ class AbstractBlockchainManager(ABC):
         """
         self.put_metadata(url.encode())
 
-    def get_manifest_url(self, hotkey: Hotkey) -> Optional[str]:
+    async def get_manifest_url(self, hotkey: Hotkey) -> Optional[str]:
         """
         Get manifest url for given neuron identified by hotkey. Returns None if url is not found.
         """
-        serialized_url: Optional[bytes] = self.get_metadata(hotkey)
+        serialized_url: Optional[bytes] = await self.get_metadata(hotkey)
         if serialized_url is None:
             return None
         try:
@@ -38,11 +37,11 @@ class AbstractBlockchainManager(ABC):
         except UnicodeDecodeError:
             return None
 
-    def get_own_manifest_url(self) -> Optional[str]:
+    async def get_own_manifest_url(self) -> Optional[str]:
         """
         Get manifest url for wallet owner. Returns None if url is not found.
         """
-        return self.get_manifest_url(self.get_hotkey())
+        return await self.get_manifest_url(self.get_hotkey())
 
     @abstractmethod
     def put_metadata(self, data: bytes):
@@ -52,7 +51,7 @@ class AbstractBlockchainManager(ABC):
         pass
 
     @abstractmethod
-    def get_metadata(self, hotkey: Hotkey) -> Optional[bytes]:
+    async def get_metadata(self, hotkey: Hotkey) -> Optional[bytes]:
         """
         Get metadata from blockchain for given neuron identified by hotkey. Returns None if metadata is not found.
         """
@@ -75,24 +74,25 @@ class BittensorBlockchainManager(AbstractBlockchainManager):
     event_processor: AbstractMinerShieldEventProcessor
 
     def __init__(
-        self,
-        subtensor: bittensor.Subtensor,
-        netuid: int,
-        wallet: bittensor_wallet.Wallet,
-        event_processor: AbstractMinerShieldEventProcessor,
+            self,
+            subtensor: bittensor.Subtensor,
+            netuid: int,
+            wallet: bittensor_wallet.Wallet,
+            event_processor: AbstractMinerShieldEventProcessor,
     ):
         self.subtensor = subtensor
         self.netuid = netuid
         self.wallet = wallet
         self.event_processor = event_processor
 
-    def get_metadata(self, hotkey: Hotkey) -> Optional[bytes]:
+    async def get_metadata(self, hotkey: Hotkey) -> Optional[bytes]:
         try:
-            metadata: dict = get_metadata(  # type: ignore
-                self.subtensor,
-                self.netuid,
-                hotkey,
-            )
+            async with bittensor.AsyncSubtensor(self.subtensor.chain_endpoint) as async_subtensor:
+                metadata: dict = await async_subtensor.substrate.query(
+                    module="Commitments",
+                    storage_function="CommitmentOf",
+                    params=[self.netuid, hotkey],
+                )
         except Exception as e:
             self.event_processor.event('Failed to get metadata for netuid={netuid}, hotkey={hotkey}',
                                        exception=e, netuid=self.netuid, hotkey=hotkey)
@@ -101,10 +101,16 @@ class BittensorBlockchainManager(AbstractBlockchainManager):
         try:
             # This structure is hardcoded in bittensor publish_metadata function, but corresponding get_metadata
             # function does not use it, so we need to extract the value manually.
-            fields: list[dict[str, str]] = metadata["info"]["fields"]
+
+            # Commented parts of the code shows how this extraction should look if async version will work properly,
+            # the same as sync version does. Now async version doesn't decode raw SCALE objects properly. I left this
+            # code as it will be easier one day to restore this proper parsing.
+            # fields: list[dict[str, str]] = metadata["info"]["fields"]
+            fields = metadata["info"]["fields"]
 
             # As for now there is only one field in metadata. Field contains map from type of data to data itself.
-            field: dict[str, str] = fields[0]
+            # field: dict[str, str] = fields[0]
+            field = fields[0][0]
 
             # Find data of 'Raw' type.
             for data_type, data in field.items():
@@ -114,7 +120,8 @@ class BittensorBlockchainManager(AbstractBlockchainManager):
                 return None
 
             # Raw data is hex-encoded and prefixed with '0x'.
-            return bytes.fromhex(data[2:])
+            # return bytes.fromhex(data[2:])
+            return bytes(data[0])
         except TypeError:
             return None
         except LookupError:

--- a/bt_ddos_shield/encryption_manager.py
+++ b/bt_ddos_shield/encryption_manager.py
@@ -25,14 +25,14 @@ class AbstractEncryptionManager(ABC):
     @abstractmethod
     def encrypt(self, public_key: PublicKey, data: bytes) -> bytes:
         """
-        Encrypts given data using the provided public key.
+        Encrypts given data using the provided public key. Throws EncryptionError if encryption fails.
         """
         pass
 
     @abstractmethod
     def decrypt(self, private_key: PrivateKey, data: bytes) -> bytes:
         """
-        Decrypts given data using the provided private key.
+        Decrypts given data using the provided private key. Throws DecryptionError if decryption fails.
         """
         pass
 

--- a/bt_ddos_shield/miner_shield.py
+++ b/bt_ddos_shield/miner_shield.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import logging
 import re
 import sys
@@ -433,7 +434,7 @@ class MinerShield:
         Publish info about current manifest file to blockchain if it is not already there.
         """
         expected_url: str = self.manifest_manager.get_manifest_url()
-        current_url: str = self.blockchain_manager.get_own_manifest_url()
+        current_url: str = asyncio.run(self.blockchain_manager.get_own_manifest_url())
         if current_url == expected_url:
             self._event("Manifest address already published")
         else:

--- a/bt_ddos_shield/miner_shield.py
+++ b/bt_ddos_shield/miner_shield.py
@@ -294,7 +294,8 @@ class MinerShield:
         """
         try:
             current_state: MinerShieldState = self.state_manager.get_state()
-            current_manifest: Manifest = self.manifest_manager.get_manifest(self.manifest_manager.get_manifest_url())
+            current_manifest: Manifest = \
+                asyncio.run(self.manifest_manager.get_manifest(self.manifest_manager.get_manifest_url()))
             new_manifest: Manifest = self.manifest_manager.create_manifest(current_state.validators_addresses,
                                                                            current_state.known_validators)
             same_content: bool = new_manifest.md5_hash == current_manifest.md5_hash

--- a/bt_ddos_shield/miner_shield.py
+++ b/bt_ddos_shield/miner_shield.py
@@ -559,7 +559,7 @@ class MinerShieldFactory:
                                                                              event_processor, state_manager)
         encryption_manager: AbstractEncryptionManager = cls.create_encryption_manager()
         manifest_manager: AbstractManifestManager = cls.create_manifest_manager(settings, encryption_manager,
-                                                                                aws_client_factory)
+                                                                                aws_client_factory, event_processor)
         blockchain_manager: AbstractBlockchainManager = cls.create_blockchain_manager(settings, event_processor)
 
         if settings.options.auto_hide_original_server:
@@ -627,9 +627,10 @@ class MinerShieldFactory:
 
     @classmethod
     def create_manifest_manager(cls, settings: ShieldSettings, encryption_manager: AbstractEncryptionManager,
-                                aws_client_factory: AWSClientFactory) -> AbstractManifestManager:
+                                aws_client_factory: AWSClientFactory,
+                                event_processor: AbstractMinerShieldEventProcessor) -> AbstractManifestManager:
         manifest_serializer: AbstractManifestSerializer = JsonManifestSerializer()
-        return S3ManifestManager(manifest_serializer, encryption_manager, aws_client_factory,
+        return S3ManifestManager(manifest_serializer, encryption_manager, event_processor, aws_client_factory,
                                  settings.aws_s3_bucket_name)
 
     @classmethod

--- a/bt_ddos_shield/shield_metagraph.py
+++ b/bt_ddos_shield/shield_metagraph.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass
 
 import bittensor
@@ -103,7 +102,10 @@ class ShieldMetagraph(Metagraph):
         if miner_manifest_url is None:
             return None
 
-        manifest: Manifest = self.manifest_manager.get_manifest(miner_manifest_url)
+        manifests: Dict[Hotkey, Optional[Manifest]] = await self.manifest_manager.get_manifests(miner_manifest_urls)
+        manifest: Optional[Manifest] = manifests.get(miner_hotkey)
+        if manifest is None:
+            return None
         url: str = self.manifest_manager.get_address_for_validator(manifest, self.wallet.hotkey.ss58_address,
                                                                    self.private_key)
         return url

--- a/bt_ddos_shield/shield_metagraph.py
+++ b/bt_ddos_shield/shield_metagraph.py
@@ -79,7 +79,8 @@ class ShieldMetagraph(Metagraph):
 
     @classmethod
     def create_default_manifest_manager(cls) -> ReadOnlyManifestManager:
-        return ReadOnlyManifestManager(JsonManifestSerializer(), ECIESEncryptionManager())
+        return ReadOnlyManifestManager(JsonManifestSerializer(), ECIESEncryptionManager(),
+                                       PrintingMinerShieldEventProcessor())
 
     @classmethod
     def create_default_blockchain_manager(

--- a/bt_ddos_shield/shield_metagraph.py
+++ b/bt_ddos_shield/shield_metagraph.py
@@ -98,7 +98,7 @@ class ShieldMetagraph(Metagraph):
 
     async def fetch_miner_address(self, miner_hotkey: Hotkey) -> str:
         while True:
-            miner_manifest_url: Optional[str] = self.blockchain_manager.get_manifest_url(miner_hotkey)
+            miner_manifest_url: Optional[str] = await self.blockchain_manager.get_manifest_url(miner_hotkey)
             if miner_manifest_url is not None:
                 break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ dependencies = [
     "bittensor~=8.5.1",
     "boto3~=1.35.27",
     "eciespy~=0.4.2",
+    "httpx~=0.28.1",
     "pydantic~=2.10.5",
     "pydantic-settings~=2.7.1",
     "python-dotenv~=1.0.1",
-    "requests~=2.32.3",
     "route53~=1.0.1",
     "sqlalchemy~=2.0.36",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "bittensor~=8.5.1",
     "boto3~=1.35.27",
     "eciespy~=0.4.2",
-    "httpx~=0.28.1",
     "pydantic~=2.10.5",
     "pydantic-settings~=2.7.1",
     "python-dotenv~=1.0.1",

--- a/tests/test_blockchain_manager.py
+++ b/tests/test_blockchain_manager.py
@@ -1,13 +1,8 @@
 import threading
-import unittest.mock
 from typing import Optional
-
-import pytest
-import websockets.exceptions
 
 from bt_ddos_shield.blockchain_manager import (
     AbstractBlockchainManager,
-    BittensorBlockchainManager,
 )
 from bt_ddos_shield.utils import Hotkey
 
@@ -30,139 +25,6 @@ class MemoryBlockchainManager(AbstractBlockchainManager):
             self.known_data[self.miner_hotkey] = data
             self.put_counter += 1
 
-    def get_metadata(self, hotkey: Hotkey) -> Optional[bytes]:
+    async def get_metadata(self, hotkey: Hotkey) -> Optional[bytes]:
         with self._lock:
             return self.known_data.get(self.miner_hotkey)
-
-
-@pytest.fixture
-def wallet_hotkey():
-    return "5EU2xVWC7qffsUNGtvakp5WCj7WGJMPkwG1dsm3qnU2Kqvee"
-
-
-@pytest.fixture
-def wallet(wallet_hotkey):
-    mock_wallet = unittest.mock.Mock()
-    mock_wallet.hotkey.ss58_address = wallet_hotkey
-    return mock_wallet
-
-
-def test_bittensor_get(wallet):
-    mock_subtensor = unittest.mock.MagicMock()
-    mock_substrate = mock_subtensor.substrate.__enter__.return_value
-    mock_substrate.query.return_value = unittest.mock.Mock(
-        value={
-            "info": {
-                "fields": None,
-            },
-        },
-    )
-
-    manager = BittensorBlockchainManager(
-        subtensor=mock_subtensor,
-        wallet=wallet,
-        netuid=1,
-        event_processor=unittest.mock.Mock(),
-    )
-
-    assert manager.get_metadata(manager.get_hotkey()) is None
-
-    mock_substrate.query.assert_called_once_with(
-        module="Commitments",
-        storage_function="CommitmentOf",
-        params=[1, "5EU2xVWC7qffsUNGtvakp5WCj7WGJMPkwG1dsm3qnU2Kqvee"],
-        block_hash=None,
-    )
-
-    mock_substrate.query.reset_mock()
-    mock_substrate.query.return_value = unittest.mock.Mock(
-        value={
-            "info": {
-                "fields": [
-                    {
-                        "Raw4": "0x64617461",
-                    },
-                ],
-            },
-        },
-    )
-
-    assert manager.get_metadata(manager.get_hotkey()) == b"data"
-
-
-def test_bittensor_put(wallet):
-    mock_subtensor = unittest.mock.MagicMock()
-    mock_substrate = mock_subtensor.substrate.__enter__.return_value
-
-    manager = BittensorBlockchainManager(
-        subtensor=mock_subtensor,
-        wallet=wallet,
-        netuid=1,
-        event_processor=unittest.mock.Mock(),
-    )
-
-    manager.put_metadata(b"data")
-
-    mock_substrate.compose_call.assert_called_once_with(
-        call_module="Commitments",
-        call_function="set_commitment",
-        call_params={
-            "netuid": 1,
-            "info": {
-                "fields": [
-                    [
-                        {
-                            "Raw4": b"data",
-                        },
-                    ],
-                ],
-            },
-        },
-    )
-    mock_substrate.create_signed_extrinsic.assert_called_once_with(
-        call=mock_substrate.compose_call.return_value,
-        keypair=wallet.hotkey,
-    )
-    mock_subtensor.substrate.submit_extrinsic.assert_called_once_with(
-        mock_substrate.create_signed_extrinsic.return_value,
-        wait_for_inclusion=True,
-        wait_for_finalization=True,
-    )
-
-
-def test_bittensor_retries(wallet):
-    mock_subtensor = unittest.mock.MagicMock()
-    mock_substrate = mock_subtensor.substrate.__enter__.return_value
-    mock_substrate.query.side_effect = (
-        websockets.exceptions.ConnectionClosed(None, None),
-        unittest.mock.Mock(
-            value={
-                "info": {
-                    "fields": [
-                        {
-                            "Raw4": "0x64617461",
-                        },
-                    ],
-                },
-            },
-        ),
-    )
-
-    manager = BittensorBlockchainManager(
-        subtensor=mock_subtensor,
-        wallet=wallet,
-        netuid=1,
-        event_processor=unittest.mock.Mock(),
-    )
-
-    assert manager.get_metadata(manager.get_hotkey()) == b"data"
-    assert mock_substrate.query.call_count == 2
-
-    mock_subtensor.substrate.submit_extrinsic.side_effect = (
-        websockets.exceptions.ConnectionClosed(None, None),
-        unittest.mock.Mock(),
-    )
-
-    manager.put_metadata(b"data")
-
-    assert mock_subtensor.substrate.submit_extrinsic.call_count == 2

--- a/tests/test_blockchain_manager.py
+++ b/tests/test_blockchain_manager.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Optional
+from typing import Optional, Iterable, Dict
 
 from bt_ddos_shield.blockchain_manager import (
     AbstractBlockchainManager,
@@ -25,6 +25,6 @@ class MemoryBlockchainManager(AbstractBlockchainManager):
             self.known_data[self.miner_hotkey] = data
             self.put_counter += 1
 
-    async def get_metadata(self, hotkey: Hotkey) -> Optional[bytes]:
+    async def get_metadata(self, hotkeys: Iterable[Hotkey]) -> Dict[Hotkey, Optional[bytes]]:
         with self._lock:
-            return self.known_data.get(self.miner_hotkey)
+            return {hotkey: self.known_data.get(hotkey) for hotkey in hotkeys}

--- a/tests/test_manifest_manager.py
+++ b/tests/test_manifest_manager.py
@@ -1,7 +1,10 @@
 import asyncio
 from typing import Optional
 
+import aiohttp
+
 from bt_ddos_shield.encryption_manager import ECIESEncryptionManager
+from bt_ddos_shield.event_processor import PrintingMinerShieldEventProcessor
 from bt_ddos_shield.manifest_manager import (
     AbstractManifestManager,
     JsonManifestSerializer,
@@ -19,7 +22,7 @@ class MemoryManifestManager(AbstractManifestManager):
     put_counter: int
 
     def __init__(self):
-        super().__init__(JsonManifestSerializer(), ECIESEncryptionManager())
+        super().__init__(JsonManifestSerializer(), ECIESEncryptionManager(), PrintingMinerShieldEventProcessor())
         self._manifest_url = 'https://manifest.com'
         self.stored_file = None
         self.put_counter = 0
@@ -31,7 +34,7 @@ class MemoryManifestManager(AbstractManifestManager):
         self.stored_file = data
         self.put_counter += 1
 
-    async def _get_manifest_file(self, url: Optional[str]) -> Optional[bytes]:
+    async def _get_manifest_file(self, http_session: aiohttp.ClientSession, url: Optional[str]) -> Optional[bytes]:
         if self.stored_file is None or url != self._manifest_url:
             return None
         return self.stored_file
@@ -59,21 +62,27 @@ class TestManifestManager:
         manifest_manager = S3ManifestManager(aws_client_factory=aws_client_factory,
                                              bucket_name=shield_settings.aws_s3_bucket_name,
                                              manifest_serializer=JsonManifestSerializer(),
-                                             encryption_manager=ECIESEncryptionManager())
+                                             encryption_manager=ECIESEncryptionManager(),
+                                             event_processor=PrintingMinerShieldEventProcessor())
+        http_session: aiohttp.ClientSession = aiohttp.ClientSession(loop=asyncio.get_event_loop())
 
-        data: bytes = b'some_data'
-        manifest_manager._put_manifest_file(data)
-        manifest_url: str = manifest_manager.get_manifest_url()
-        retrieved_data: Optional[bytes] = asyncio.run(manifest_manager._get_manifest_file(manifest_url))
-        assert retrieved_data == data
-        assert asyncio.run(manifest_manager._get_manifest_file(manifest_url + 'xxx')) is None
+        try:
+            data: bytes = b'some_data'
+            manifest_manager._put_manifest_file(data)
+            manifest_url: str = manifest_manager.get_manifest_url()
+            retrieved_data: Optional[bytes] = asyncio.run(manifest_manager._get_manifest_file(http_session, manifest_url))
+            assert retrieved_data == data
+            assert asyncio.run(manifest_manager._get_manifest_file(http_session, manifest_url + 'xxx')) is None
 
-        other_data: bytes = b'other_data'
-        manifest_manager._put_manifest_file(other_data)
-        retrieved_data = asyncio.run(manifest_manager._get_manifest_file(manifest_url))
-        assert retrieved_data == other_data
+            other_data: bytes = b'other_data'
+            manifest_manager._put_manifest_file(other_data)
+            retrieved_data = asyncio.run(manifest_manager._get_manifest_file(http_session, manifest_url))
+            assert retrieved_data == other_data
 
-        validator_manifest_manager = ReadOnlyManifestManager(manifest_serializer=JsonManifestSerializer(),
-                                                             encryption_manager=ECIESEncryptionManager())
-        retrieved_data = asyncio.run(validator_manifest_manager._get_manifest_file(manifest_url))
-        assert retrieved_data == other_data
+            validator_manifest_manager = ReadOnlyManifestManager(manifest_serializer=JsonManifestSerializer(),
+                                                                 encryption_manager=ECIESEncryptionManager(),
+                                                                 event_processor=PrintingMinerShieldEventProcessor())
+            retrieved_data = asyncio.run(validator_manifest_manager._get_manifest_file(http_session, manifest_url))
+            assert retrieved_data == other_data
+        finally:
+            http_session.close()

--- a/tests/test_manifest_manager.py
+++ b/tests/test_manifest_manager.py
@@ -70,7 +70,8 @@ class TestManifestManager:
             data: bytes = b'some_data'
             manifest_manager._put_manifest_file(data)
             manifest_url: str = manifest_manager.get_manifest_url()
-            retrieved_data: Optional[bytes] = asyncio.run(manifest_manager._get_manifest_file(http_session, manifest_url))
+            retrieved_data: Optional[bytes] = asyncio.run(manifest_manager._get_manifest_file(http_session,
+                                                                                              manifest_url))
             assert retrieved_data == data
             assert asyncio.run(manifest_manager._get_manifest_file(http_session, manifest_url + 'xxx')) is None
 

--- a/tests/test_miner_shield.py
+++ b/tests/test_miner_shield.py
@@ -1,6 +1,6 @@
 import asyncio
 from time import sleep
-from typing import Optional
+from typing import Optional, Dict
 
 import bittensor_wallet
 from bt_ddos_shield.address_manager import AbstractAddressManager
@@ -159,7 +159,8 @@ class TestMinerShield:
             manifest_url: str = manifest_manager.get_manifest_url()
             manifest: Manifest = manifest_manager.get_manifest(manifest_url)
             assert manifest.encrypted_url_mapping.keys() == state.validators_addresses.keys()
-            assert asyncio.run(blockchain_manager.get_manifest_url(miner_hotkey)) == manifest_url
+            urls: Dict[Hotkey, Optional[str]] = asyncio.run(blockchain_manager.get_manifest_urls([miner_hotkey]))
+            assert urls[miner_hotkey] == manifest_url
 
             reloaded_state: MinerShieldState = state_manager.get_state(reload=True)
             assert reloaded_state == state
@@ -174,7 +175,8 @@ class TestMinerShield:
             assert state.validators_addresses == {}
             manifest: Manifest = manifest_manager.get_manifest(manifest_url)
             assert manifest.encrypted_url_mapping == {}
-            assert asyncio.run(blockchain_manager.get_manifest_url(miner_hotkey)) == manifest_url
+            urls = asyncio.run(blockchain_manager.get_manifest_urls([miner_hotkey]))
+            assert urls[miner_hotkey] == manifest_url
 
             reloaded_state: MinerShieldState = state_manager.get_state(reload=True)
             assert reloaded_state == state

--- a/tests/test_miner_shield.py
+++ b/tests/test_miner_shield.py
@@ -95,7 +95,7 @@ class TestMinerShield:
             assert self.manifest_manager.stored_file is not None
             assert self.manifest_manager.put_counter == 1
             manifest_url: str = self.manifest_manager.get_manifest_url()
-            manifest: Manifest = self.manifest_manager.get_manifest(manifest_url)
+            manifest: Manifest = asyncio.run(self.manifest_manager.get_manifest(manifest_url))
             assert manifest.encrypted_url_mapping.keys() == state.validators_addresses.keys()
             assert asyncio.run(self.blockchain_manager.get_own_manifest_url()) == manifest_url
             assert self.blockchain_manager.put_counter == 1
@@ -157,7 +157,7 @@ class TestMinerShield:
             assert state.banned_validators == {}
             assert state.validators_addresses.keys() == validators_manager.get_validators().keys()
             manifest_url: str = manifest_manager.get_manifest_url()
-            manifest: Manifest = manifest_manager.get_manifest(manifest_url)
+            manifest: Manifest = asyncio.run(manifest_manager.get_manifest(manifest_url))
             assert manifest.encrypted_url_mapping.keys() == state.validators_addresses.keys()
             urls: Dict[Hotkey, Optional[str]] = asyncio.run(blockchain_manager.get_manifest_urls([miner_hotkey]))
             assert urls[miner_hotkey] == manifest_url
@@ -173,7 +173,7 @@ class TestMinerShield:
             state = state_manager.get_state()
             assert state.known_validators == {}
             assert state.validators_addresses == {}
-            manifest: Manifest = manifest_manager.get_manifest(manifest_url)
+            manifest: Manifest = asyncio.run(manifest_manager.get_manifest(manifest_url))
             assert manifest.encrypted_url_mapping == {}
             urls = asyncio.run(blockchain_manager.get_manifest_urls([miner_hotkey]))
             assert urls[miner_hotkey] == manifest_url

--- a/tests/test_miner_shield.py
+++ b/tests/test_miner_shield.py
@@ -1,3 +1,4 @@
+import asyncio
 from time import sleep
 from typing import Optional
 
@@ -96,7 +97,7 @@ class TestMinerShield:
             manifest_url: str = self.manifest_manager.get_manifest_url()
             manifest: Manifest = self.manifest_manager.get_manifest(manifest_url)
             assert manifest.encrypted_url_mapping.keys() == state.validators_addresses.keys()
-            assert self.blockchain_manager.get_own_manifest_url() == manifest_url
+            assert asyncio.run(self.blockchain_manager.get_own_manifest_url()) == manifest_url
             assert self.blockchain_manager.put_counter == 1
         finally:
             self.shield.disable()
@@ -158,7 +159,7 @@ class TestMinerShield:
             manifest_url: str = manifest_manager.get_manifest_url()
             manifest: Manifest = manifest_manager.get_manifest(manifest_url)
             assert manifest.encrypted_url_mapping.keys() == state.validators_addresses.keys()
-            assert blockchain_manager.get_manifest_url(miner_hotkey) == manifest_url
+            assert asyncio.run(blockchain_manager.get_manifest_url(miner_hotkey)) == manifest_url
 
             reloaded_state: MinerShieldState = state_manager.get_state(reload=True)
             assert reloaded_state == state
@@ -173,7 +174,7 @@ class TestMinerShield:
             assert state.validators_addresses == {}
             manifest: Manifest = manifest_manager.get_manifest(manifest_url)
             assert manifest.encrypted_url_mapping == {}
-            assert blockchain_manager.get_manifest_url(miner_hotkey) == manifest_url
+            assert asyncio.run(blockchain_manager.get_manifest_url(miner_hotkey)) == manifest_url
 
             reloaded_state: MinerShieldState = state_manager.get_state(reload=True)
             assert reloaded_state == state

--- a/uv.lock
+++ b/uv.lock
@@ -293,10 +293,10 @@ dependencies = [
     { name = "bittensor", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "boto3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "eciespy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "route53", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "sqlalchemy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
@@ -326,10 +326,10 @@ requires-dist = [
     { name = "bittensor", specifier = "~=8.5.1" },
     { name = "boto3", specifier = "~=1.35.27" },
     { name = "eciespy", specifier = "~=0.4.2" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = "~=2.10.5" },
     { name = "pydantic-settings", specifier = "~=2.7.1" },
     { name = "python-dotenv", specifier = "~=1.0.1" },
-    { name = "requests", specifier = "~=2.32.3" },
     { name = "route53", specifier = "~=1.0.1" },
     { name = "sqlalchemy", specifier = "~=2.0.36" },
 ]
@@ -691,6 +691,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpcore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,6 @@ dependencies = [
     { name = "bittensor", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "boto3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "eciespy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -326,7 +325,6 @@ requires-dist = [
     { name = "bittensor", specifier = "~=8.5.1" },
     { name = "boto3", specifier = "~=1.35.27" },
     { name = "eciespy", specifier = "~=0.4.2" },
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = "~=2.10.5" },
     { name = "pydantic-settings", specifier = "~=2.7.1" },
     { name = "python-dotenv", specifier = "~=1.0.1" },
@@ -691,34 +689,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "httpcore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]


### PR DESCRIPTION
When syncing metagraph on validator's side, addresses for miners which are shielded and prepared address for our validator are replaced with these prepared addresses